### PR TITLE
TSK: Upgrade solidity from v0.6.x to v0.8.x

### DIFF
--- a/smart-contract/contracts/Calculations.sol
+++ b/smart-contract/contracts/Calculations.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.6;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.17;
 
 import "./lib/contracts-ethereum-package/math/SafeMath.sol";
 

--- a/smart-contract/contracts/FusedController.sol
+++ b/smart-contract/contracts/FusedController.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.6;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.17;
 
 import "./lib/contracts-ethereum-package/Initializable.sol";
 

--- a/smart-contract/contracts/IVICoin.sol
+++ b/smart-contract/contracts/IVICoin.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.6;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.17;
 
 import "./lib/contracts-ethereum-package/token/ERC20/IERC20.sol";
 

--- a/smart-contract/contracts/IVICoinAdjustable.sol
+++ b/smart-contract/contracts/IVICoinAdjustable.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.6;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.17;
 
 import "./IVICoin.sol";
 

--- a/smart-contract/contracts/Migrations.sol
+++ b/smart-contract/contracts/Migrations.sol
@@ -1,10 +1,11 @@
-pragma solidity ^0.6.6;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.17;
 
 contract Migrations {
     address public owner;
     uint256 public last_completed_migration;
 
-    constructor() public {
+    constructor(){
         owner = msg.sender;
     }
 

--- a/smart-contract/contracts/VICoin.sol
+++ b/smart-contract/contracts/VICoin.sol
@@ -38,7 +38,6 @@ struct Settings {
 contract VICoin is Initializable, ERC20BurnableUpgradeSafe, FusedController {
     using SafeMath for uint256;
     using SafeMath for int256;
-    using Calculations for *;
 
     Settings settings;
     mapping(address => uint256) public lastTransactionBlock;
@@ -94,14 +93,6 @@ contract VICoin is Initializable, ERC20BurnableUpgradeSafe, FusedController {
     receive() external payable {
         revert("Do not send money to the contract");
     }
-
-//    function calcNumCompletedPeriods(
-//        uint256 _blockNumber,
-//        uint256 _lastGenerationBlock,
-//        uint256 _generationPeriod
-//    ) public pure returns (uint256){
-//        return Calculations.calcNumCompletedPeriods(_blockNumber,_lastGenerationBlock,_generationPeriod);
-//    }
 
     /** @notice Manually trigger an onchain update of the live balance
         @return Generation accrued since last balance update */

--- a/smart-contract/contracts/VICoin.sol
+++ b/smart-contract/contracts/VICoin.sol
@@ -1,11 +1,12 @@
-pragma solidity ^0.6.6;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.17;
 
 /**
     @title An open source smart contract for a UBI token with demurrage that
         gives control of the currency to the community, with adjustable
         parameters.
     @author The Value Instrument Team
-    @notice 
+    @notice
     @dev This contract was developed for solc 0.6.6
 */
 
@@ -37,6 +38,7 @@ struct Settings {
 contract VICoin is Initializable, ERC20BurnableUpgradeSafe, FusedController {
     using SafeMath for uint256;
     using SafeMath for int256;
+    using Calculations for *;
 
     Settings settings;
     mapping(address => uint256) public lastTransactionBlock;
@@ -92,6 +94,14 @@ contract VICoin is Initializable, ERC20BurnableUpgradeSafe, FusedController {
     receive() external payable {
         revert("Do not send money to the contract");
     }
+
+//    function calcNumCompletedPeriods(
+//        uint256 _blockNumber,
+//        uint256 _lastGenerationBlock,
+//        uint256 _generationPeriod
+//    ) public pure returns (uint256){
+//        return Calculations.calcNumCompletedPeriods(_blockNumber,_lastGenerationBlock,_generationPeriod);
+//    }
 
     /** @notice Manually trigger an onchain update of the live balance
         @return Generation accrued since last balance update */
@@ -384,7 +394,7 @@ contract VICoin is Initializable, ERC20BurnableUpgradeSafe, FusedController {
     }
 
     /** @notice Return community contribution, to 2 decimal places
-        @return The percentage that will be taken from the transaction fee 
+        @return The percentage that will be taken from the transaction fee
                 as a community contribution (2 d.p) */
     function getCommunityContribution() external view returns (uint256) {
         return settings.communityContribution;

--- a/smart-contract/contracts/VICoinAdjustable.sol
+++ b/smart-contract/contracts/VICoinAdjustable.sol
@@ -1,11 +1,12 @@
-pragma solidity ^0.6.6;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.17;
 
 /**
     @title An open source smart contract for a UBI token with demurrage that
         gives control of the currency to the community, with adjustable
         parameters.
     @author The Value Instrument Team
-    @notice 
+    @notice
 */
 
 import "./VICoin.sol";

--- a/smart-contract/contracts/lib/contracts-ethereum-package/GSN/Context.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/GSN/Context.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 import "../Initializable.sol";
 
 /*
@@ -26,7 +27,7 @@ contract ContextUpgradeSafe is Initializable {
 
 
     function _msgSender() internal view virtual returns (address payable) {
-        return msg.sender;
+        return payable(msg.sender);
     }
 
     function _msgData() internal view virtual returns (bytes memory) {

--- a/smart-contract/contracts/lib/contracts-ethereum-package/GSN/GSNRecipient.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/GSN/GSNRecipient.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 import "./IRelayRecipient.sol";
 import "./IRelayHub.sol";
@@ -99,7 +100,7 @@ abstract contract GSNRecipientUpgradeSafe is Initializable, IRelayRecipient, Con
      */
     function _msgSender() internal view virtual override returns (address payable) {
         if (msg.sender != _relayHub) {
-            return msg.sender;
+            return payable(msg.sender);
         } else {
             return _getRelayedCallSender();
         }

--- a/smart-contract/contracts/lib/contracts-ethereum-package/GSN/GSNRecipientERC20Fee.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/GSN/GSNRecipientERC20Fee.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 import "./GSNRecipient.sol";
 import "../math/SafeMath.sol";
@@ -129,7 +130,7 @@ contract __unstable__ERC20Owned is Initializable, ERC20UpgradeSafe, OwnableUpgra
     uint256 private constant _UINT256_MAX = 2**256 - 1;
 
 
-    constructor(string memory name, string memory symbol) public  {
+    constructor(string memory name, string memory symbol)  {
         ____unstable__ERC20Owned_init(name, symbol);
     }
 

--- a/smart-contract/contracts/lib/contracts-ethereum-package/GSN/GSNRecipientERC20Fee.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/GSN/GSNRecipientERC20Fee.sol
@@ -96,7 +96,7 @@ contract GSNRecipientERC20FeeUpgradeSafe is Initializable, GSNRecipientUpgradeSa
         (address from, uint256 maxPossibleCharge) = abi.decode(context, (address, uint256));
 
         // The maximum token charge is pre-charged from the user
-        _token.safeTransferFrom(from, address(this), maxPossibleCharge);
+       _token.safeTransferFrom(from, address(this), maxPossibleCharge);
     }
 
     /**

--- a/smart-contract/contracts/lib/contracts-ethereum-package/GSN/GSNRecipientSignature.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/GSN/GSNRecipientSignature.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 import "./GSNRecipient.sol";
 import "../cryptography/ECDSA.sol";

--- a/smart-contract/contracts/lib/contracts-ethereum-package/GSN/IRelayHub.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/GSN/IRelayHub.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 /**
  * @dev Interface for `RelayHub`, the core contract of the GSN. Users should not need to interact with this contract

--- a/smart-contract/contracts/lib/contracts-ethereum-package/GSN/IRelayRecipient.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/GSN/IRelayRecipient.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 /**
  * @dev Base interface for a contract that will be called via the GSN from {IRelayHub}.

--- a/smart-contract/contracts/lib/contracts-ethereum-package/Initializable.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/Initializable.sol
@@ -1,4 +1,5 @@
-pragma solidity >=0.4.24 <0.7.0;
+// SPDX-License-Identifier: ISC
+pragma solidity >=0.4.24 <0.9.0;
 
 
 /**

--- a/smart-contract/contracts/lib/contracts-ethereum-package/access/AccessControl.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/access/AccessControl.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 import "../utils/EnumerableSet.sol";
 import "../utils/Address.sol";

--- a/smart-contract/contracts/lib/contracts-ethereum-package/access/Ownable.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/access/Ownable.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 import "../GSN/Context.sol";
 import "../Initializable.sol";

--- a/smart-contract/contracts/lib/contracts-ethereum-package/cryptography/ECDSA.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/cryptography/ECDSA.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 /**
  * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.

--- a/smart-contract/contracts/lib/contracts-ethereum-package/cryptography/MerkleProof.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/cryptography/MerkleProof.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 /**
  * @dev These functions deal with verification of Merkle trees (hash trees),

--- a/smart-contract/contracts/lib/contracts-ethereum-package/math/Math.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/math/Math.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 /**
  * @dev Standard math utilities missing in the Solidity language.

--- a/smart-contract/contracts/lib/contracts-ethereum-package/math/SafeMath.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/math/SafeMath.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 /**
  * @dev Wrappers over Solidity's arithmetic operations with added overflow

--- a/smart-contract/contracts/lib/contracts-ethereum-package/math/SignedSafeMath.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/math/SignedSafeMath.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 /**
  * @title SignedSafeMath

--- a/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/ERC20.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/ERC20.sol
@@ -55,9 +55,9 @@ contract ERC20UpgradeSafe is Initializable, ContextUpgradeSafe, IERC20 {
      * construction.
      */
 
-    function __ERC20_init(string memory initName, string memory initSymbol) internal initializer {
+    function __ERC20_init(string memory tokenName, string memory tokenSymbol) internal initializer {
         __Context_init_unchained();
-        __ERC20_init_unchained(initName, initSymbol);
+        __ERC20_init_unchained(tokenName, tokenSymbol);
     }
 
     function __ERC20_init_unchained(string memory tokenName, string memory tokenSymbol) internal initializer {

--- a/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/ERC20.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/ERC20.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 import "../../GSN/Context.sol";
 import "./IERC20.sol";
@@ -54,16 +55,16 @@ contract ERC20UpgradeSafe is Initializable, ContextUpgradeSafe, IERC20 {
      * construction.
      */
 
-    function __ERC20_init(string memory name, string memory symbol) internal initializer {
+    function __ERC20_init(string memory initName, string memory initSymbol) internal initializer {
         __Context_init_unchained();
-        __ERC20_init_unchained(name, symbol);
+        __ERC20_init_unchained(initName, initSymbol);
     }
 
-    function __ERC20_init_unchained(string memory name, string memory symbol) internal initializer {
+    function __ERC20_init_unchained(string memory tokenName, string memory tokenSymbol) internal initializer {
 
 
-        _name = name;
-        _symbol = symbol;
+        _name = tokenName;
+        _symbol = tokenSymbol;
         _decimals = 18;
 
     }

--- a/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/ERC20Burnable.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/ERC20Burnable.sol
@@ -43,9 +43,8 @@ abstract contract ERC20BurnableUpgradeSafe is
      * `amount`.
      */
     function burnFrom(address account, uint256 amount) public virtual {
+        require(amount > allowance(account, _msgSender()), "ERC20: burn amount exceeds allowance");
         uint256 decreasedAllowance = allowance(account, _msgSender()) - amount;
-        require(decreaseAllowance > 0, "ERC20: burn amount exceeds allowance");
-
         _approve(account, _msgSender(), decreasedAllowance);
         _burn(account, amount);
     }

--- a/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/ERC20Burnable.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/ERC20Burnable.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 import "../../GSN/Context.sol";
 import "./ERC20.sol";
@@ -42,10 +43,8 @@ abstract contract ERC20BurnableUpgradeSafe is
      * `amount`.
      */
     function burnFrom(address account, uint256 amount) public virtual {
-        uint256 decreasedAllowance = allowance(account, _msgSender()).sub(
-            amount,
-            "ERC20: burn amount exceeds allowance"
-        );
+        uint256 decreasedAllowance = allowance(account, _msgSender()) - amount;
+        require(decreaseAllowance > 0, "ERC20: burn amount exceeds allowance");
 
         _approve(account, _msgSender(), decreasedAllowance);
         _burn(account, amount);

--- a/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/ERC20Capped.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/ERC20Capped.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 import "./ERC20.sol";
 import "../../Initializable.sol";
@@ -14,16 +15,16 @@ abstract contract ERC20CappedUpgradeSafe is Initializable, ERC20UpgradeSafe {
      * set once during construction.
      */
 
-    function __ERC20Capped_init(uint256 cap) internal initializer {
+    function __ERC20Capped_init(uint256 tokenCap) internal initializer {
         __Context_init_unchained();
-        __ERC20Capped_init_unchained(cap);
+        __ERC20Capped_init_unchained(tokenCap);
     }
 
-    function __ERC20Capped_init_unchained(uint256 cap) internal initializer {
+    function __ERC20Capped_init_unchained(uint256 tokenCap) internal initializer {
 
 
-        require(cap > 0, "ERC20Capped: cap is 0");
-        _cap = cap;
+        require(tokenCap > 0, "ERC20Capped: cap is 0");
+        _cap = tokenCap;
 
     }
 
@@ -46,7 +47,7 @@ abstract contract ERC20CappedUpgradeSafe is Initializable, ERC20UpgradeSafe {
         super._beforeTokenTransfer(from, to, amount);
 
         if (from == address(0)) { // When minting tokens
-            require(totalSupply().add(amount) <= _cap, "ERC20Capped: cap exceeded");
+            require(totalSupply() + amount <= _cap, "ERC20Capped: cap exceeded");
         }
     }
 

--- a/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/ERC20Pausable.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/ERC20Pausable.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 import "./ERC20.sol";
 import "../../utils/Pausable.sol";

--- a/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/ERC20Snapshot.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/ERC20Snapshot.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 import "../../math/SafeMath.sol";
 import "../../utils/Arrays.sol";

--- a/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/IERC20.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/IERC20.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 /**
  * @dev Interface of the ERC20 standard as defined in the EIP.

--- a/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/SafeERC20.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/SafeERC20.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 import "./IERC20.sol";
 import "../../math/SafeMath.sol";

--- a/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/TokenTimelock.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/TokenTimelock.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 import "./SafeERC20.sol";
 import "../../Initializable.sol";
@@ -25,18 +26,18 @@ contract TokenTimelockUpgradeSafe is Initializable {
     uint256 private _releaseTime;
 
 
-    function __TokenTimelock_init(IERC20 token, address beneficiary, uint256 releaseTime) internal initializer {
-        __TokenTimelock_init_unchained(token, beneficiary, releaseTime);
+    function __TokenTimelock_init(IERC20 initToken, address initBeneficiary, uint256 initReleaseTime) internal initializer {
+        __TokenTimelock_init_unchained(initToken, initBeneficiary, initReleaseTime);
     }
 
-    function __TokenTimelock_init_unchained(IERC20 token, address beneficiary, uint256 releaseTime) internal initializer {
+    function __TokenTimelock_init_unchained(IERC20 initToken, address initBeneficiary, uint256 initReleaseTime) internal initializer {
 
 
         // solhint-disable-next-line not-rely-on-time
-        require(releaseTime > block.timestamp, "TokenTimelock: release time is before current time");
-        _token = token;
-        _beneficiary = beneficiary;
-        _releaseTime = releaseTime;
+        require(initReleaseTime > block.timestamp, "TokenTimelock: release time is before current time");
+        _token = initToken;
+        _beneficiary = initBeneficiary;
+        _releaseTime = initReleaseTime;
 
     }
 

--- a/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/TokenTimelock.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/token/ERC20/TokenTimelock.sol
@@ -26,18 +26,18 @@ contract TokenTimelockUpgradeSafe is Initializable {
     uint256 private _releaseTime;
 
 
-    function __TokenTimelock_init(IERC20 initToken, address initBeneficiary, uint256 initReleaseTime) internal initializer {
-        __TokenTimelock_init_unchained(initToken, initBeneficiary, initReleaseTime);
+    function __TokenTimelock_init(IERC20 timelockToken, address timelockBeneficiary, uint256 timelockReleaseTime) internal initializer {
+        __TokenTimelock_init_unchained(timelockToken, timelockBeneficiary, timelockReleaseTime);
     }
 
-    function __TokenTimelock_init_unchained(IERC20 initToken, address initBeneficiary, uint256 initReleaseTime) internal initializer {
+    function __TokenTimelock_init_unchained(IERC20 timelockToken, address timelockBeneficiary, uint256 timelockReleaseTime) internal initializer {
 
 
         // solhint-disable-next-line not-rely-on-time
-        require(initReleaseTime > block.timestamp, "TokenTimelock: release time is before current time");
-        _token = initToken;
-        _beneficiary = initBeneficiary;
-        _releaseTime = initReleaseTime;
+        require(timelockReleaseTime > block.timestamp, "TokenTimelock: release time is before current time");
+        _token = timelockToken;
+        _beneficiary = timelockBeneficiary;
+        _releaseTime = timelockReleaseTime;
 
     }
 

--- a/smart-contract/contracts/lib/contracts-ethereum-package/utils/Address.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/utils/Address.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.2;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 /**
  * @dev Collection of functions related to the address type

--- a/smart-contract/contracts/lib/contracts-ethereum-package/utils/Arrays.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/utils/Arrays.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 import "../math/Math.sol";
 

--- a/smart-contract/contracts/lib/contracts-ethereum-package/utils/Counters.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/utils/Counters.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 import "../math/SafeMath.sol";
 

--- a/smart-contract/contracts/lib/contracts-ethereum-package/utils/Create2.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/utils/Create2.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 /**
  * @dev Helper to make usage of the `CREATE2` EVM opcode easier and safer.

--- a/smart-contract/contracts/lib/contracts-ethereum-package/utils/EnumerableMap.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/utils/EnumerableMap.sol
@@ -213,7 +213,7 @@ library EnumerableMap {
     */
     function at(UintToAddressMap storage map, uint256 index) internal view returns (uint256, address) {
         (bytes32 key, bytes32 value) = _at(map._inner, index);
-        return (uint256(key), address(uint160(uint256(index))));
+        return (uint256(key), address(uint160(uint256(value))));
     }
 
     /**

--- a/smart-contract/contracts/lib/contracts-ethereum-package/utils/EnumerableMap.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/utils/EnumerableMap.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 /**
  * @dev Library for managing an enumerable variant of Solidity's
@@ -175,7 +176,7 @@ library EnumerableMap {
      * already present.
      */
     function set(UintToAddressMap storage map, uint256 key, address value) internal returns (bool) {
-        return _set(map._inner, bytes32(key), bytes32(uint256(value)));
+        return _set(map._inner, bytes32(key), bytes32(uint256(uint160(value))));
     }
 
     /**
@@ -212,7 +213,7 @@ library EnumerableMap {
     */
     function at(UintToAddressMap storage map, uint256 index) internal view returns (uint256, address) {
         (bytes32 key, bytes32 value) = _at(map._inner, index);
-        return (uint256(key), address(uint256(value)));
+        return (uint256(key), address(uint160(uint256(index))));
     }
 
     /**
@@ -223,13 +224,13 @@ library EnumerableMap {
      * - `key` must be in the map.
      */
     function get(UintToAddressMap storage map, uint256 key) internal view returns (address) {
-        return address(uint256(_get(map._inner, bytes32(key))));
+        return address(uint160(uint256(_get(map._inner, bytes32(key)))));
     }
 
     /**
      * @dev Same as {get}, with a custom error message when `key` is not in the map.
      */
     function get(UintToAddressMap storage map, uint256 key, string memory errorMessage) internal view returns (address) {
-        return address(uint256(_get(map._inner, bytes32(key), errorMessage)));
+        return address(uint160(uint256(_get(map._inner, bytes32(key), errorMessage))));
     }
 }

--- a/smart-contract/contracts/lib/contracts-ethereum-package/utils/EnumerableSet.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/utils/EnumerableSet.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 /**
  * @dev Library for managing
@@ -143,7 +144,7 @@ library EnumerableSet {
      * already present.
      */
     function add(AddressSet storage set, address value) internal returns (bool) {
-        return _add(set._inner, bytes32(uint256(value)));
+        return _add(set._inner, bytes32(uint256(uint160(value))));
     }
 
     /**
@@ -153,14 +154,14 @@ library EnumerableSet {
      * present.
      */
     function remove(AddressSet storage set, address value) internal returns (bool) {
-        return _remove(set._inner, bytes32(uint256(value)));
+        return _remove(set._inner, bytes32(uint256(uint160(value))));
     }
 
     /**
      * @dev Returns true if the value is in the set. O(1).
      */
     function contains(AddressSet storage set, address value) internal view returns (bool) {
-        return _contains(set._inner, bytes32(uint256(value)));
+        return _contains(set._inner, bytes32(uint256(uint160(value))));
     }
 
     /**
@@ -181,7 +182,7 @@ library EnumerableSet {
     * - `index` must be strictly less than {length}.
     */
     function at(AddressSet storage set, uint256 index) internal view returns (address) {
-        return address(uint256(_at(set._inner, index)));
+        return address(uint160(uint256(_at(set._inner, index))));
     }
 
 

--- a/smart-contract/contracts/lib/contracts-ethereum-package/utils/Pausable.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/utils/Pausable.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 import "../GSN/Context.sol";
 import "../Initializable.sol";

--- a/smart-contract/contracts/lib/contracts-ethereum-package/utils/ReentrancyGuard.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/utils/ReentrancyGuard.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 import "../Initializable.sol";
 
 /**

--- a/smart-contract/contracts/lib/contracts-ethereum-package/utils/SafeCast.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/utils/SafeCast.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 
 /**

--- a/smart-contract/contracts/lib/contracts-ethereum-package/utils/Strings.sol
+++ b/smart-contract/contracts/lib/contracts-ethereum-package/utils/Strings.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: ISC
+pragma solidity ^0.8.0;
 
 /**
  * @dev String operations.
@@ -24,7 +25,7 @@ library Strings {
         uint256 index = digits - 1;
         temp = value;
         while (temp != 0) {
-            buffer[index--] = byte(uint8(48 + temp % 10));
+            buffer[index--] = bytes1(uint8(48 + temp % 10));
             temp /= 10;
         }
         return string(buffer);

--- a/smart-contract/migrations/2_deploy_vicoin.js
+++ b/smart-contract/migrations/2_deploy_vicoin.js
@@ -1,7 +1,7 @@
 var VICoin = artifacts.require("./VICoin.sol");
 var CalculationsLib = artifacts.require("./Calculations.sol")
 
-module.exports = function (deployer) {
+module.exports = async function (deployer) {
   /**
    * @param name {string} - Token name, e.g. VI Berlin.
    * @param symbol {string} - Token symbol, e.g. VALUE.
@@ -69,14 +69,32 @@ module.exports = function (deployer) {
     communityContributionAccount = "0x0000000000000000000000000000000000000000",
     controller = "0x0000000000000000000000000000000000000000";
 
-  deployer.then(async()=>{
+  // deployer.then(async()=>{
     await deployer.deploy(CalculationsLib)
     await deployer.link(CalculationsLib, VICoin)
+
     await deployer.deploy(
         VICoin,
+        [
+          name,
+          symbol,
+          lifetimeInBlocks,
+          generationAmount,
+          generationPeriod,
+          communityContributionPercentage,
+          transactionFeePercentage,
+          initialBalance,
+          communityContributionAccount,
+          controller
+        ],
+        { deployer}
+    );
+  // })
+
+  const contract = await VICoin.deployed()
+    await contract.initialize(
         name,
         symbol,
-        decimals,
         lifetimeInBlocks,
         generationAmount,
         generationPeriod,
@@ -84,9 +102,9 @@ module.exports = function (deployer) {
         transactionFeePercentage,
         initialBalance,
         communityContributionAccount,
-        controller
-    );
-  })
+        controller)
+  const contractName = await contract.name.call()
+  console.log("VIContract deployed", {contractName,address: contract.address} )
 
 };
 

--- a/smart-contract/migrations/2_deploy_vicoin.js
+++ b/smart-contract/migrations/2_deploy_vicoin.js
@@ -1,5 +1,4 @@
 var VICoin = artifacts.require("./VICoin.sol");
-var CalculationsLib = artifacts.require("./Calculations.sol")
 
 module.exports = async function (deployer) {
   /**
@@ -69,30 +68,8 @@ module.exports = async function (deployer) {
     communityContributionAccount = "0x0000000000000000000000000000000000000000",
     controller = "0x0000000000000000000000000000000000000000";
 
-  // deployer.then(async()=>{
-    await deployer.deploy(CalculationsLib)
-    await deployer.link(CalculationsLib, VICoin)
-
     await deployer.deploy(
         VICoin,
-        [
-          name,
-          symbol,
-          lifetimeInBlocks,
-          generationAmount,
-          generationPeriod,
-          communityContributionPercentage,
-          transactionFeePercentage,
-          initialBalance,
-          communityContributionAccount,
-          controller
-        ],
-        { deployer}
-    );
-  // })
-
-  const contract = await VICoin.deployed()
-    await contract.initialize(
         name,
         symbol,
         lifetimeInBlocks,
@@ -102,10 +79,8 @@ module.exports = async function (deployer) {
         transactionFeePercentage,
         initialBalance,
         communityContributionAccount,
-        controller)
-  const contractName = await contract.name.call()
-  console.log("VIContract deployed", {contractName,address: contract.address} )
-
+        controller,
+    );
 };
 
 /**

--- a/smart-contract/migrations/2_deploy_vicoin.js
+++ b/smart-contract/migrations/2_deploy_vicoin.js
@@ -1,4 +1,5 @@
 var VICoin = artifacts.require("./VICoin.sol");
+var CalculationsLib = artifacts.require("./Calculations.sol")
 
 module.exports = function (deployer) {
   /**
@@ -68,20 +69,25 @@ module.exports = function (deployer) {
     communityContributionAccount = "0x0000000000000000000000000000000000000000",
     controller = "0x0000000000000000000000000000000000000000";
 
-  deployer.deploy(
-    VICoin,
-    name,
-    symbol,
-    decimals,
-    lifetimeInBlocks,
-    generationAmount,
-    generationPeriod,
-    communityContributionPercentage,
-    transactionFeePercentage,
-    initialBalance,
-    communityContributionAccount,
-    controller
-  );
+  deployer.then(async()=>{
+    await deployer.deploy(CalculationsLib)
+    await deployer.link(CalculationsLib, VICoin)
+    await deployer.deploy(
+        VICoin,
+        name,
+        symbol,
+        decimals,
+        lifetimeInBlocks,
+        generationAmount,
+        generationPeriod,
+        communityContributionPercentage,
+        transactionFeePercentage,
+        initialBalance,
+        communityContributionAccount,
+        controller
+    );
+  })
+
 };
 
 /**

--- a/smart-contract/test/testvicoin.js
+++ b/smart-contract/test/testvicoin.js
@@ -1,5 +1,4 @@
 var VICoin = artifacts.require("VICoin");
-var Calculations = artifacts.require("Calculations");
 const truffleAssert = require("truffle-assertions");
 const chalk = require("chalk");
 

--- a/smart-contract/test/testvicoin.js
+++ b/smart-contract/test/testvicoin.js
@@ -1,4 +1,5 @@
 var VICoin = artifacts.require("VICoin");
+var Calculations = artifacts.require("Calculations");
 const truffleAssert = require("truffle-assertions");
 const chalk = require("chalk");
 

--- a/smart-contract/truffle-config.js
+++ b/smart-contract/truffle-config.js
@@ -62,7 +62,7 @@ module.exports = {
           enabled: true,
         },
       },
-      version: "0.6.6",
+      version: "^0.8.17",
     },
   },
 };

--- a/smart-contract/truffle-config.js
+++ b/smart-contract/truffle-config.js
@@ -62,7 +62,7 @@ module.exports = {
           enabled: true,
         },
       },
-      version: "^0.8.17",
+      version: "0.8.17",
     },
   },
 };


### PR DESCRIPTION
- Upgrade all contracts to base version 0.8
- Add license reference to solidity version - I used ISC based on project license?
- Update address referrences to be compatible with changes [ in docs here](https://docs.soliditylang.org/en/latest/types.html#address)
- Update changes for bytes32 and uint256 conversions